### PR TITLE
Fixing Example and Adding Keyword Arguments as option for parameters

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,6 +31,9 @@ Try the example app `time_app.py`_ with the ``--help`` flag to see what settings
 
 .. _`time_app.py`: https://github.com/rhasspy/rhasspy-hermes-app/blob/master/examples/time_app.py
 
+You can pass all the settings as keyword arguments inside the constructor aswell:
+:meth:`HermesApp("ExampleApp", host = "192.168.178.123", port = 12183)`
+
 *******
 Asyncio
 *******
@@ -65,7 +68,7 @@ If the API of this library changes, your app possibly stops working when it upda
 
 .. code-block::
 
-  rhasspy-hermes-app==0.2.0
+  rhasspy-hermes-app==1.0.0
 
 This way your app keeps working when the Rhasspy Hermes App adds incompatible changes in a new version.
 

--- a/examples/async_advice_app.py
+++ b/examples/async_advice_app.py
@@ -16,7 +16,7 @@ This is JUST an example!
 None of the authors, contributors, administrators, or anyone else connected with Rhasspy_Hermes_App,
 in any way whatsoever, can be responsible for your use of the api endpoint.
 """
-URL = 'https://api.advicslip.com/advice'
+URL = 'https://api.adviceslip.com/advice'
 
 @app.on_intent("GetAdvice")
 async def get_advice(intent: NluIntent):

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -105,11 +105,15 @@ class HermesApp(HermesClient):
         hermes_cli.add_hermes_args(parser)
 
         # Parse command-line arguments
-        self.args = parser.parse_args()
-
-        # Option to set all parameters as keyword arguments !!! CLI arguments are rated higher priority
-        args_dict = vars(self.args)
-        args_dict = {**kwargs, **args_dict}
+        # Command-line arguments take precedence over the arguments of the HermesApp.__init__
+        args_dict = vars(parser.parse_args())
+        default_args_dict = vars(parser.parse_args([]))
+        # Remove the arguments which have their default values
+        non_default_args_dict = dict(set(args_dict.items()) - set(default_args_dict.items()))
+        # Let the non-default arguments take precedence over the object arguments
+        args = {**kwargs, **non_default_args_dict}
+        # Merge these back with the original arguments, taking into account precedence
+        self.args = argparse.Namespace(**{**args_dict, **args})
 
         # Set up logging
         hermes_cli.setup_logging(self.args)

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -108,9 +108,7 @@ class HermesApp(HermesClient):
         self.args = parser.parse_args()
 
         # Option to set all parameters as keyword arguments !!! CLI arguments are rated higher priority
-        args_dict = vars(self.args)
-        for key, value in kwargs.items():
-            args_dict[key] = args_dict[key] if key in args_dict else value
+        args_dict = {**kwargs, **vars(self.args)}
 
         # Set up logging
         hermes_cli.setup_logging(self.args)

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -85,6 +85,7 @@ class HermesApp(HermesClient):
         name: str,
         parser: Optional[argparse.ArgumentParser] = None,
         mqtt_client: Optional[mqtt.Client] = None,
+        **kwargs
     ):
         """Initialize the Rhasspy Hermes app.
 
@@ -105,6 +106,11 @@ class HermesApp(HermesClient):
 
         # Parse command-line arguments
         self.args = parser.parse_args()
+
+        # Option to set all parameters as keyword arguments
+        args_dict = vars(self.args)
+        for key, value in kwargs.items():
+            args_dict[key] = value
 
         # Set up logging
         hermes_cli.setup_logging(self.args)

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -108,7 +108,7 @@ class HermesApp(HermesClient):
         # overwrite argument defaults inside parser with argparse.SUPPRESS
         # so arguments that are not provided get ignored
         suppress_parser = deepcopy(parser)
-        for action in vars(suppress_parser)["_actions"]:
+        for action in suppress_parser._actions:
             action.default = argparse.SUPPRESS
 
         supplied_args = vars(suppress_parser.parse_args())

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -108,7 +108,8 @@ class HermesApp(HermesClient):
         self.args = parser.parse_args()
 
         # Option to set all parameters as keyword arguments !!! CLI arguments are rated higher priority
-        args_dict = {**kwargs, **vars(self.args)}
+        args_dict = vars(self.args)
+        args_dict = {**kwargs, **args_dict}
 
         # Set up logging
         hermes_cli.setup_logging(self.args)

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -107,10 +107,10 @@ class HermesApp(HermesClient):
         # Parse command-line arguments
         self.args = parser.parse_args()
 
-        # Option to set all parameters as keyword arguments
+        # Option to set all parameters as keyword arguments !!! CLI arguments are rated higher priority
         args_dict = vars(self.args)
         for key, value in kwargs.items():
-            args_dict[key] = value
+            args_dict[key] = args_dict[key] if key in args_dict else value
 
         # Set up logging
         hermes_cli.setup_logging(self.args)

--- a/rhasspyhermes_app/__init__.py
+++ b/rhasspyhermes_app/__init__.py
@@ -109,7 +109,9 @@ class HermesApp(HermesClient):
         args_dict = vars(parser.parse_args())
         default_args_dict = vars(parser.parse_args([]))
         # Remove the arguments which have their default values
-        non_default_args_dict = dict(set(args_dict.items()) - set(default_args_dict.items()))
+        non_default_args_dict = dict(
+            set(args_dict.items()) - set(default_args_dict.items())
+        )
         # Let the non-default arguments take precedence over the object arguments
         args = {**kwargs, **non_default_args_dict}
         # Merge these back with the original arguments, taking into account precedence
@@ -124,6 +126,7 @@ class HermesApp(HermesClient):
             mqtt_client = mqtt.Client()
 
         # Initialize HermesClient
+        # pylint: disable=no-member
         super().__init__(name, mqtt_client, site_ids=self.args.site_id)
 
         self._callbacks_hotword: List[Callable[[HotwordDetected], Awaitable[None]]] = []
@@ -602,6 +605,7 @@ class HermesApp(HermesClient):
         self._subscribe_callbacks()
 
         # Try to connect
+        # pylint: disable=no-member
         _LOGGER.debug("Connecting to %s:%s", self.args.host, self.args.port)
         hermes_cli.connect(self.mqtt_client, self.args)
         self.mqtt_client.loop_start()

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -75,7 +75,7 @@ def test_if_cli_arguments_overwrite_init_arguments(mocker):
             "--username",
             "rhasspy-hermes-app",
             "--password",
-            "test"
+            "test",
         ],
     )
     app = HermesApp(
@@ -91,3 +91,46 @@ def test_if_cli_arguments_overwrite_init_arguments(mocker):
     assert app.args.port == 1883
     assert app.args.username == "rhasspy-hermes-app"
     assert app.args.password == "test"
+
+
+def test_if_cli_arguments_overwrite_init_arguments_with_argument_parser(mocker):
+    """Test whether arguments from the command line overwrite arguments to a HermesApp object
+    if the user supplies their own ArgumentParser object."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "rhasspy-hermes-app-test",
+            "--host",
+            "rhasspy.home",
+            "--port",
+            "1883",
+            "--username",
+            "rhasspy-hermes-app",
+            "--password",
+            "test",
+            "--test-argument",
+            "foobar",
+            "--test-flag",
+        ],
+    )
+    parser = argparse.ArgumentParser(prog="rhasspy-hermes-app-test")
+    parser.add_argument("--test-argument", default="foo")
+    parser.add_argument("--test-flag", action="store_true")
+
+    app = HermesApp(
+        "Test arguments in init",
+        parser=parser,
+        mqtt_client=mocker.MagicMock(),
+        host="rhasspy.local",
+        port=8883,
+        username="rhasspy-hermes-app-test",
+        password="covfefe",
+        test_argument="bar",
+    )
+
+    assert app.args.host == "rhasspy.home"
+    assert app.args.port == 1883
+    assert app.args.username == "rhasspy-hermes-app"
+    assert app.args.password == "test"
+    assert app.args.test_argument == "foobar"
+    assert app.args.test_flag == True

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -3,7 +3,6 @@ import argparse
 import pytest
 import sys
 
-import rhasspyhermes.cli as hermes_cli
 from rhasspyhermes_app import HermesApp
 
 
@@ -72,26 +71,23 @@ def test_if_cli_arguments_overwrite_init_arguments(mocker):
             "--host",
             "rhasspy.home",
             "--port",
-            "8883",
-            "--tls",
+            "1883",
             "--username",
             "rhasspy-hermes-app",
             "--password",
-            "test",
+            "test"
         ],
     )
     app = HermesApp(
         "Test arguments in init",
         mqtt_client=mocker.MagicMock(),
         host="rhasspy.local",
-        port=1883,
-        tls=False,
+        port=8883,
         username="rhasspy-hermes-app-test",
         password="covfefe",
     )
 
     assert app.args.host == "rhasspy.home"
-    assert app.args.port == 8883
-    assert app.args.tls == True
+    assert app.args.port == 1883
     assert app.args.username == "rhasspy-hermes-app"
     assert app.args.password == "test"

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,97 @@
+"""Tests for HermesApp arguments."""
+import argparse
+import pytest
+import sys
+
+import rhasspyhermes.cli as hermes_cli
+from rhasspyhermes_app import HermesApp
+
+
+def test_default_arguments(mocker):
+    """Test whether default arguments are set up correctly in a HermesApp object."""
+    app = HermesApp("Test default arguments", mqtt_client=mocker.MagicMock())
+
+    assert app.args.host == "localhost"
+    assert app.args.port == 1883
+    assert app.args.tls == False
+    assert app.args.username is None
+    assert app.args.password is None
+
+
+def test_arguments_from_cli(mocker):
+    """Test whether arguments from the command line are set up correctly in a HermesApp object."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "rhasspy-hermes-app-test",
+            "--host",
+            "rhasspy.home",
+            "--port",
+            "8883",
+            "--tls",
+            "--username",
+            "rhasspy-hermes-app",
+            "--password",
+            "test",
+        ],
+    )
+    app = HermesApp("Test arguments in init", mqtt_client=mocker.MagicMock())
+
+    assert app.args.host == "rhasspy.home"
+    assert app.args.port == 8883
+    assert app.args.tls == True
+    assert app.args.username == "rhasspy-hermes-app"
+    assert app.args.password == "test"
+
+
+def test_arguments_in_init(mocker):
+    """Test whether arguments are set up correctly while initializing a HermesApp object."""
+    app = HermesApp(
+        "Test arguments in init",
+        mqtt_client=mocker.MagicMock(),
+        host="rhasspy.home",
+        port=8883,
+        tls=True,
+        username="rhasspy-hermes-app",
+        password="test",
+    )
+
+    assert app.args.host == "rhasspy.home"
+    assert app.args.port == 8883
+    assert app.args.tls == True
+    assert app.args.username == "rhasspy-hermes-app"
+    assert app.args.password == "test"
+
+
+def test_if_cli_arguments_overwrite_init_arguments(mocker):
+    """Test whether arguments from the command line overwrite arguments to a HermesApp object."""
+    mocker.patch(
+        "sys.argv",
+        [
+            "rhasspy-hermes-app-test",
+            "--host",
+            "rhasspy.home",
+            "--port",
+            "8883",
+            "--tls",
+            "--username",
+            "rhasspy-hermes-app",
+            "--password",
+            "test",
+        ],
+    )
+    app = HermesApp(
+        "Test arguments in init",
+        mqtt_client=mocker.MagicMock(),
+        host="rhasspy.local",
+        port=1883,
+        tls=False,
+        username="rhasspy-hermes-app-test",
+        password="covfefe",
+    )
+
+    assert app.args.host == "rhasspy.home"
+    assert app.args.port == 8883
+    assert app.args.tls == True
+    assert app.args.username == "rhasspy-hermes-app"
+    assert app.args.password == "test"


### PR DESCRIPTION
1. This fixes a small typo in the async example
2. Just by adding a few lines of code, it enables the functionality to pass parameters in code. (Issue #15 ) e.g:
`python
app = HermesApp("AdviceApp", host = "192.168.178.123", port = 12183)
`

Not sure if it should be restricted to the existing parameters (or some parameters exclusively) or not. I'm leaning towards no restrictions. 