### PR TITLE
Clarify which port rhasspy uses by default for MQTT.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,7 +39,7 @@ command line have precedence over arguments passed to the constructor.
 Connecting to Rhasspy
 *********************
 
-In its default configuration, Rhasspy's internal MQTT broker listens on port 12183, so this is what you need to connect to.
+In its default configuration, Rhasspy's internal MQTT broker listens on port 12183, so this is what you need to connect to, using command-line or constructor arguments - see previous section for details.
 
 If you are using docker, you will need to add to add this port to your `docker-compose.yml` file:
 
@@ -50,6 +50,8 @@ If you are using docker, you will need to add to add this port to your `docker-c
       ports:
         - "12101:12101"   # this is the port used for the web interface
         - "12183:12183"   # you need this to access Rhasspy's MQTT port
+
+If you're using an external MQTT broker, you probably want port 1883.  This is what most MQTT brokers use, and is Rhasspy Hermes App's default port.
 
 
 *******

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,6 +35,23 @@ You can pass all the settings as keyword arguments inside the constructor as wel
 ``rhasspyhermes_app.HermesApp("ExampleApp", host="192.168.178.123", port=12183)``. Note that arguments passed on the
 command line have precedence over arguments passed to the constructor.
 
+*********************
+Connecting to Rhasspy
+*********************
+
+In its default configuration, Rhasspy's internal MQTT broker listens on port 12183, so this is what you need to connect to.
+
+If you are using docker, you will need to add to add this port to your `docker-compose.yml` file:
+
+.. code-block::
+
+  services:
+    rhasspy:
+      ports:
+        - "12101:12101"   # this is the port used for the web interface
+        - "12183:12183"   # you need this to access Rhasspy's MQTT port
+
+
 *******
 Asyncio
 *******


### PR DESCRIPTION
Doc update to tell people what Rhasspy's default MQTT port is.  It is not prominent in Rhasspy's documentation.

After I tried the example apps and 1883 didn't work, I tried using 12101.  The app connected and printed some debug information (no errors), so appeared to be working.  But it didn't receive up the expected MQTT messages.  After digging into the issue queue I found https://github.com/rhasspy/rhasspy-hermes-app/issues/14 and that clued me in.  Then there was the matter of adjusting the docker config to expose this port.

I think this deserves to be added to the docs in a prominent spot.

